### PR TITLE
feat(http): introduce generalized HttpStatusException for improved http code and error handling

### DIFF
--- a/commands/integrations/src/main/java/top/chiloven/lukosbot2/commands/bot/bilibili/BilibiliApi.kt
+++ b/commands/integrations/src/main/java/top/chiloven/lukosbot2/commands/bot/bilibili/BilibiliApi.kt
@@ -24,6 +24,7 @@ import tools.jackson.databind.node.ObjectNode
 import top.chiloven.lukosbot2.Constants
 import top.chiloven.lukosbot2.commands.bot.bilibili.schema.VideoId
 import top.chiloven.lukosbot2.util.HttpJson
+import top.chiloven.lukosbot2.util.HttpStatusException
 import top.chiloven.lukosbot2.util.JsonUtils.int
 import top.chiloven.lukosbot2.util.JsonUtils.long
 import top.chiloven.lukosbot2.util.JsonUtils.obj
@@ -80,7 +81,7 @@ class BilibiliApi {
     }
 
     fun getViewData(id: VideoId): ObjectNode? {
-        val root = HttpJson.getObject(
+        val root = HttpJson.getObjectResponse(
             uri = VIEW_API_URL,
             params = when (id) {
                 is VideoId.Bv -> mapOf("bvid" to id.bvid)
@@ -88,18 +89,18 @@ class BilibiliApi {
             },
             headers = JSON_HEADERS,
             readTimeoutMs = API_CALL_TIMEOUT_MS.toInt(),
-        )
+        ).body
         if (root.int("code") != 0) return null
         return root.obj("data")
     }
 
     fun getFollowerCount(mid: Long): Long? = runCatching {
-        val root = HttpJson.getObject(
+        val root = HttpJson.getObjectResponse(
             uri = RELATION_API_URL,
             params = mapOf("vmid" to mid.toString()),
             headers = JSON_HEADERS,
             readTimeoutMs = RELATION_TIMEOUT_MS.toInt(),
-        )
+        ).body
         if (root.int("code") != 0) return@runCatching null
         root.obj("data")?.long("follower")
     }.getOrNull()
@@ -116,7 +117,12 @@ class BilibiliApi {
     }
 
     private fun resolveLocation(url: String): String? {
-        noRedirectHttp.newCall(htmlRequest(url)).execute().use { response ->
+        val request = htmlRequest(url)
+        noRedirectHttp.newCall(request).execute().use { response ->
+            if (response.code !in 300..399 && !response.isSuccessful) {
+                throw HttpStatusException.fromResponse(response)
+            }
+
             return firstNonBlank(
                 response.header("Location"),
                 response.header("location"),
@@ -127,7 +133,12 @@ class BilibiliApi {
     }
 
     private fun resolveFinalVideoId(url: String): VideoId? {
-        redirectingHttp.newCall(htmlRequest(url)).execute().use { response ->
+        val request = htmlRequest(url)
+        redirectingHttp.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw HttpStatusException.fromResponse(response)
+            }
+
             VideoId.parse(response.request.url.toString())?.let { return it }
             return VideoId.parse(response.body.string())
         }

--- a/commands/integrations/src/main/java/top/chiloven/lukosbot2/commands/bot/github/GitHubApi.kt
+++ b/commands/integrations/src/main/java/top/chiloven/lukosbot2/commands/bot/github/GitHubApi.kt
@@ -71,11 +71,11 @@ class GitHubApi(token: String?) {
             token?.let { put("Authorization", "Bearer $it") }
         }
 
-        return HttpJson.getObject(
+        return HttpJson.getObjectResponse(
             uri = BASE + path,
             params = query,
             headers = headers
-        )
+        ).body
     }
 
     private fun MutableMap<String, String>.putIfNotBlank(key: String, value: String?) {

--- a/commands/integrations/src/main/java/top/chiloven/lukosbot2/commands/bot/ip/provider/impl/IpQueryIoProvider.kt
+++ b/commands/integrations/src/main/java/top/chiloven/lukosbot2/commands/bot/ip/provider/impl/IpQueryIoProvider.kt
@@ -43,7 +43,7 @@ class IpQueryIoProvider : IIpProvider {
     override fun priority(): Int = 100
 
     override fun query(ip: String): IpData {
-        val obj = HttpJson.getObject("$BASE/$ip")
+        val obj = HttpJson.getObjectResponse("$BASE/$ip").body
 
         val isp = obj.obj("isp")
         val location = obj.obj("location")

--- a/commands/integrations/src/main/java/top/chiloven/lukosbot2/commands/bot/ip/provider/impl/IpSbProvider.kt
+++ b/commands/integrations/src/main/java/top/chiloven/lukosbot2/commands/bot/ip/provider/impl/IpSbProvider.kt
@@ -40,7 +40,7 @@ class IpSbProvider : IIpProvider {
     override fun priority(): Int = 80
 
     override fun query(ip: String): IpData {
-        val obj = HttpJson.getObject("$BASE/geoip/$ip")
+        val obj = HttpJson.getObjectResponse("$BASE/geoip/$ip").body
 
         return IpData(
             ip = obj.str("ip") ?: ip,

--- a/commands/integrations/src/main/java/top/chiloven/lukosbot2/commands/bot/music/provider/IMusicProvider.kt
+++ b/commands/integrations/src/main/java/top/chiloven/lukosbot2/commands/bot/music/provider/IMusicProvider.kt
@@ -19,7 +19,6 @@ package top.chiloven.lukosbot2.commands.bot.music.provider
 
 import top.chiloven.lukosbot2.commands.bot.music.MusicPlatform
 import top.chiloven.lukosbot2.commands.bot.music.TrackInfo
-import java.net.http.HttpClient
 
 interface IMusicProvider {
 
@@ -53,14 +52,5 @@ interface IMusicProvider {
      */
     @Throws(Exception::class)
     fun resolveLink(link: String): TrackInfo?
-
-    companion object {
-
-        /**
-         * HTTP client instance
-         */
-        @JvmField
-        val HTTP: HttpClient = HttpClient.newHttpClient()
-    }
 
 }

--- a/commands/integrations/src/main/java/top/chiloven/lukosbot2/commands/bot/music/provider/SoundCloudMusicProvider.kt
+++ b/commands/integrations/src/main/java/top/chiloven/lukosbot2/commands/bot/music/provider/SoundCloudMusicProvider.kt
@@ -21,17 +21,13 @@ import org.jspecify.annotations.NonNull
 import tools.jackson.databind.node.ObjectNode
 import top.chiloven.lukosbot2.commands.bot.music.MusicPlatform
 import top.chiloven.lukosbot2.commands.bot.music.TrackInfo
-import top.chiloven.lukosbot2.util.JsonUtils.MAPPER
+import top.chiloven.lukosbot2.util.HttpJson
 import top.chiloven.lukosbot2.util.JsonUtils.arr
 import top.chiloven.lukosbot2.util.JsonUtils.long
 import top.chiloven.lukosbot2.util.JsonUtils.obj
 import top.chiloven.lukosbot2.util.JsonUtils.str
 import top.chiloven.lukosbot2.util.StringUtils.firstNonBlank
 import java.net.URI
-import java.net.URLEncoder
-import java.net.http.HttpRequest
-import java.net.http.HttpResponse
-import java.nio.charset.StandardCharsets
 
 class SoundCloudMusicProvider(
     private val clientId: String
@@ -47,20 +43,14 @@ class SoundCloudMusicProvider(
 
     @Throws(Exception::class)
     override fun searchTrack(query: String): TrackInfo? {
-        val encoded = URLEncoder.encode(query, StandardCharsets.UTF_8)
-        val url = "$API_BASE_V2/search/tracks?q=$encoded&client_id=$clientId&limit=1"
-
-        val req = HttpRequest.newBuilder()
-            .uri(URI.create(url))
-            .GET()
-            .build()
-
-        val resp = IMusicProvider.HTTP.send(req, HttpResponse.BodyHandlers.ofString())
-        if (resp.statusCode() != 200) {
-            throw RuntimeException("SoundCloud search error: ${resp.body()}")
-        }
-
-        val root = MAPPER.readTree(resp.body()).asObject()
+        val root = HttpJson.getObjectResponse(
+            uri = URI("$API_BASE_V2/search/tracks"),
+            params = mapOf(
+                "q" to query,
+                "client_id" to clientId,
+                "limit" to "1",
+            ),
+        ).body
         val collection = root.arr("collection")
         if (collection == null || collection.size() == 0) return null
 
@@ -70,20 +60,13 @@ class SoundCloudMusicProvider(
 
     @Throws(Exception::class)
     override fun resolveLink(link: String): TrackInfo {
-        val encoded = URLEncoder.encode(link, StandardCharsets.UTF_8)
-        val url = "$API_BASE_V2/resolve?url=$encoded&client_id=$clientId"
-
-        val req = HttpRequest.newBuilder()
-            .uri(URI.create(url))
-            .GET()
-            .build()
-
-        val resp = IMusicProvider.HTTP.send(req, HttpResponse.BodyHandlers.ofString())
-        if (resp.statusCode() != 200) {
-            throw RuntimeException("SoundCloud resolve error: ${resp.body()}")
-        }
-
-        val t = MAPPER.readTree(resp.body()).asObject()
+        val t = HttpJson.getObjectResponse(
+            uri = URI("$API_BASE_V2/resolve"),
+            params = mapOf(
+                "url" to link,
+                "client_id" to clientId,
+            ),
+        ).body
         return toTrackInfo(t)
     }
 

--- a/commands/integrations/src/main/java/top/chiloven/lukosbot2/commands/bot/music/provider/SpotifyMusicProvider.kt
+++ b/commands/integrations/src/main/java/top/chiloven/lukosbot2/commands/bot/music/provider/SpotifyMusicProvider.kt
@@ -17,9 +17,13 @@
  */
 package top.chiloven.lukosbot2.commands.bot.music.provider
 
+import okhttp3.FormBody
+import okhttp3.Request
 import tools.jackson.databind.node.ObjectNode
 import top.chiloven.lukosbot2.commands.bot.music.MusicPlatform
 import top.chiloven.lukosbot2.commands.bot.music.TrackInfo
+import top.chiloven.lukosbot2.util.HttpJson
+import top.chiloven.lukosbot2.util.HttpText
 import top.chiloven.lukosbot2.util.JsonUtils.MAPPER
 import top.chiloven.lukosbot2.util.JsonUtils.arr
 import top.chiloven.lukosbot2.util.JsonUtils.int
@@ -27,11 +31,7 @@ import top.chiloven.lukosbot2.util.JsonUtils.long
 import top.chiloven.lukosbot2.util.JsonUtils.obj
 import top.chiloven.lukosbot2.util.JsonUtils.str
 import java.net.URI
-import java.net.URLEncoder
-import java.net.http.HttpRequest
-import java.net.http.HttpResponse
 import java.nio.charset.StandardCharsets
-import java.time.Duration
 import java.util.*
 
 class SpotifyMusicProvider(
@@ -44,11 +44,11 @@ class SpotifyMusicProvider(
         private const val TOKEN_URL = "https://accounts.spotify.com/api/token"
         private const val API_BASE = "https://api.spotify.com/v1"
         private val TRACK_ID_RE = Regex("""/track/([^?#\s/]+)""")
+
     }
 
     @Volatile
     private var accessToken: String? = null
-
     @Volatile
     private var tokenExpireAtMs: Long = 0L
 
@@ -57,21 +57,16 @@ class SpotifyMusicProvider(
     @Throws(Exception::class)
     override fun searchTrack(query: String): TrackInfo? {
         val token = ensureToken()
-        val encoded = URLEncoder.encode(query, StandardCharsets.UTF_8)
-        val url = "$API_BASE/search?q=$encoded&type=track&limit=1"
+        val root = HttpJson.getObjectResponse(
+            uri = URI("$API_BASE/search"),
+            params = mapOf(
+                "q" to query,
+                "type" to "track",
+                "limit" to "1",
+            ),
+            headers = bearerHeaders(token),
+        ).body
 
-        val req = HttpRequest.newBuilder()
-            .uri(URI.create(url))
-            .header("Authorization", "Bearer $token")
-            .GET()
-            .build()
-
-        val resp = IMusicProvider.HTTP.send(req, HttpResponse.BodyHandlers.ofString())
-        if (resp.statusCode() != 200) {
-            throw RuntimeException("Spotify search error: ${resp.body()}")
-        }
-
-        val root = MAPPER.readTree(resp.body()).asObject()
         val tracks = root.obj("tracks") ?: return null
         val items = tracks.arr("items") ?: return null
         if (items.size() == 0) return null
@@ -82,22 +77,12 @@ class SpotifyMusicProvider(
     @Throws(Exception::class)
     override fun resolveLink(link: String): TrackInfo? {
         val id = extractTrackIdFromLink(link)?.takeIf { it.isNotBlank() } ?: return null
-
         val token = ensureToken()
-        val url = "$API_BASE/tracks/$id"
 
-        val req = HttpRequest.newBuilder()
-            .uri(URI.create(url))
-            .header("Authorization", "Bearer $token")
-            .GET()
-            .build()
-
-        val resp = IMusicProvider.HTTP.send(req, HttpResponse.BodyHandlers.ofString())
-        if (resp.statusCode() != 200) {
-            throw RuntimeException("Spotify track error: ${resp.body()}")
-        }
-
-        val root = MAPPER.readTree(resp.body()).asObject()
+        val root = HttpJson.getObjectResponse(
+            uri = URI("$API_BASE/tracks/$id"),
+            headers = bearerHeaders(token),
+        ).body
         return toTrackInfo(root)
     }
 
@@ -114,20 +99,19 @@ class SpotifyMusicProvider(
             "$clientId:$clientSecret".toByteArray(StandardCharsets.UTF_8)
         )
 
-        val req = HttpRequest.newBuilder()
-            .uri(URI.create(TOKEN_URL))
-            .timeout(Duration.ofSeconds(10))
+        val req = Request.Builder()
+            .url(TOKEN_URL)
             .header("Authorization", "Basic $basic")
-            .header("Content-Type", "application/x-www-form-urlencoded")
-            .POST(HttpRequest.BodyPublishers.ofString("grant_type=client_credentials"))
+            .header("Accept", "application/json")
+            .post(
+                FormBody.Builder()
+                    .add("grant_type", "client_credentials")
+                    .build()
+            )
             .build()
 
-        val resp = IMusicProvider.HTTP.send(req, HttpResponse.BodyHandlers.ofString())
-        if (resp.statusCode() != 200) {
-            throw RuntimeException("Spotify token error: ${resp.body()}")
-        }
-
-        val root = MAPPER.readTree(resp.body()).asObject()
+        val body = HttpText.sendStringResponse(req, timeoutMs = 10_000).body
+        val root = MAPPER.readTree(body).asObject()
         val token = root.str("access_token").orEmpty()
         val expiresIn = root.int("expires_in") ?: 0
 
@@ -135,6 +119,12 @@ class SpotifyMusicProvider(
         tokenExpireAtMs = now + expiresIn * 1000L
         return token
     }
+
+    private fun bearerHeaders(token: String): Map<String, String> = mapOf(
+        "Accept" to "application/json",
+        "Accept-Encoding" to "identity",
+        "Authorization" to "Bearer $token",
+    )
 
     private fun toTrackInfo(t: ObjectNode): TrackInfo {
         val id = t.str("id").orEmpty()

--- a/commands/media/src/main/java/top/chiloven/lukosbot2/commands/bot/e621/E621Api.kt
+++ b/commands/media/src/main/java/top/chiloven/lukosbot2/commands/bot/e621/E621Api.kt
@@ -66,11 +66,11 @@ object E621Api {
             "search[linked_user_name]" to searchLinkedUserName
         ).mapNotNull { (key, value) -> value?.let { key to it.toString() } }.toMap()
 
-        return HttpJson.getArray(API.resolve("artists.json"), params)
+        return HttpJson.getArrayResponse(API.resolve("artists.json"), params).body
     }
 
     fun getArtistsXIdOrName(idOrName: String): ObjectNode =
-        HttpJson.getObject(API.resolve("artists/$idOrName.json"))
+        HttpJson.getObjectResponse(API.resolve("artists/$idOrName.json")).body
 
     fun getPosts(
         limit: Int? = null,
@@ -87,7 +87,7 @@ object E621Api {
             "random" to random
         ).mapNotNull { (key, value) -> value?.let { key to it.toString() } }.toMap()
 
-        val root = HttpJson.getObject(API.resolve("posts.json"), params)
+        val root = HttpJson.getObjectResponse(API.resolve("posts.json"), params).body
         root.arr("posts")?.let { return it }
         root.obj("post")?.let { postObj ->
             return MAPPER.createArrayNode().add(postObj)
@@ -96,12 +96,12 @@ object E621Api {
     }
 
     fun getPostsXRandom(tags: String? = null): ObjectNode =
-        HttpJson.getObject(
+        HttpJson.getObjectResponse(
             API.resolve("posts/random.json"),
             mapOf("tags" to tags).filterValues { it != null }
-        ).obj("post")!!
+        ).body.obj("post")!!
 
     fun getPostsXId(id: String): ObjectNode =
-        HttpJson.getObject(API.resolve("posts/$id.json")).obj("post")!!
+        HttpJson.getObjectResponse(API.resolve("posts/$id.json")).body.obj("post")!!
 
 }

--- a/commands/media/src/main/java/top/chiloven/lukosbot2/commands/bot/e621/SearchGridRenderer.kt
+++ b/commands/media/src/main/java/top/chiloven/lukosbot2/commands/bot/e621/SearchGridRenderer.kt
@@ -19,6 +19,7 @@ package top.chiloven.lukosbot2.commands.bot.e621
 
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import org.apache.logging.log4j.LogManager
 import top.chiloven.lukosbot2.Constants
 import top.chiloven.lukosbot2.commands.UsageImageUtils
 import top.chiloven.lukosbot2.commands.bot.e621.schema.Post
@@ -35,6 +36,8 @@ import kotlin.math.ceil
 import kotlin.math.sqrt
 
 object SearchGridRenderer {
+
+    private val log = LogManager.getLogger(SearchGridRenderer::class.java)
 
     private data class BadgeColors(
         val fg: Color,
@@ -67,11 +70,15 @@ object SearchGridRenderer {
 
         return try {
             http.newCall(req).execute().use { resp ->
-                if (!resp.isSuccessful) return null
+                if (!resp.isSuccessful) {
+                    log.debug("Thumbnail load failed: code={}, url={}", resp.code, url)
+                    return null
+                }
                 val body = resp.body
                 ImageIO.read(body.bytes().inputStream())
             }
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            log.debug("Thumbnail load failed: url={}", url, e)
             null
         }
     }

--- a/commands/media/src/main/java/top/chiloven/lukosbot2/commands/bot/kemono/KemonoAPI.kt
+++ b/commands/media/src/main/java/top/chiloven/lukosbot2/commands/bot/kemono/KemonoAPI.kt
@@ -45,63 +45,63 @@ object KemonoAPI {
         service: Service,
         creatorId: String,
         postId: String
-    ): ObjectNode = HttpJson.getObject(
+    ): ObjectNode = HttpJson.getObjectResponse(
         resolve("v1/$service/user/$creatorId/post/$postId"),
         headers = HEADER
-    )
+    ).body
 
     @Throws(IOException::class)
     fun getCreatorProfile(
         service: Service,
         creatorId: String
-    ): ObjectNode = HttpJson.getObject(
+    ): ObjectNode = HttpJson.getObjectResponse(
         resolve("v1/$service/user/$creatorId/profile"),
         headers = HEADER
-    )
+    ).body
 
     @Throws(IOException::class)
     fun getCreatorLinks(
         service: Service,
         creatorId: String
-    ): ArrayNode = HttpJson.getArray(
+    ): ArrayNode = HttpJson.getArrayResponse(
         resolve("v1/$service/user/$creatorId/links"),
         headers = HEADER
-    )
+    ).body
 
     @Throws(IOException::class)
     fun getCreatorPosts(
         service: Service,
         creatorId: String
-    ): ArrayNode = HttpJson.getArray(
+    ): ArrayNode = HttpJson.getArrayResponse(
         resolve("v1/$service/user/$creatorId/posts"),
         headers = HEADER
-    )
+    ).body
 
     @Throws(IOException::class)
-    fun getDiscordChannelPost(channelId: String): ArrayNode = HttpJson.getArray(
+    fun getDiscordChannelPost(channelId: String): ArrayNode = HttpJson.getArrayResponse(
         resolve("v1/discord/channel/$channelId"),
         headers = HEADER
-    )
+    ).body
 
     @Throws(IOException::class)
-    fun getDiscordServerChannel(channelId: String): ArrayNode = HttpJson.getArray(
+    fun getDiscordServerChannel(channelId: String): ArrayNode = HttpJson.getArrayResponse(
         resolve("v1/discord/channel/lookup/$channelId"),
         headers = HEADER
-    )
+    ).body
 
     @Throws(IOException::class)
-    fun getFileFromHash(hash: String): ObjectNode = HttpJson.getObject(
+    fun getFileFromHash(hash: String): ObjectNode = HttpJson.getObjectResponse(
         resolve("v1/search_hash/$hash"),
         headers = HEADER
-    )
+    ).body
 
     @Throws(IOException::class)
     fun getPostFromServicePost(
         service: Service,
         servicePostId: String
-    ): ObjectNode = HttpJson.getObject(
+    ): ObjectNode = HttpJson.getObjectResponse(
         resolve("v1/$service/post/$servicePostId"),
         headers = HEADER
-    )
+    ).body
 
 }

--- a/commands/media/src/main/java/top/chiloven/lukosbot2/commands/bot/kemono/KemonoCommand.kt
+++ b/commands/media/src/main/java/top/chiloven/lukosbot2/commands/bot/kemono/KemonoCommand.kt
@@ -206,11 +206,18 @@ class KemonoCommand(
     }
 
     private fun friendlyError(e: Throwable): String {
-        val msg = e.message?.trim() ?: ""
-        return when {
-            msg.startsWith("HTTP 404") -> "资源未找到，请检查链接、ID、SHA-256 或平台参数是否正确。"
-            msg.isNotEmpty() -> "处理失败：$msg"
-            else -> "处理失败，请稍后再试。"
+        return when (e) {
+            is HttpStatusException -> when (e.statusCode) {
+                404 -> "资源未找到，请检查链接、ID、SHA-256 或平台参数是否正确。"
+                429 -> "远端服务请求过于频繁，请稍后再试。"
+                in 500..599 -> "远端服务暂时不可用，请稍后再试。"
+                else -> "远端请求失败：HTTP ${e.statusCode}"
+            }
+
+            else -> {
+                val msg = e.message?.trim().orEmpty()
+                if (msg.isNotEmpty()) "处理失败：$msg" else "处理失败，请稍后再试。"
+            }
         }
     }
 
@@ -430,11 +437,11 @@ class KemonoCommand(
         val token = appProperties.telegram.botToken.trim()
         require(token.isNotEmpty()) { "当前无法读取 Telegram 上传文件，请直接提供 SHA-256。" }
 
-        val root = HttpJson.getObject(
+        val root = HttpJson.getObjectResponse(
             URI.create("https://api.telegram.org/bot$token/getFile"),
             mapOf("file_id" to fileId),
             null
-        )
+        ).body
         val filePath = root.obj("result")?.str("file_path")
             ?: throw IOException("无法读取 Telegram 上传文件路径")
         return "https://api.telegram.org/file/bot$token/$filePath"
@@ -449,7 +456,7 @@ class KemonoCommand(
 
         okHttp.newCall(request).execute().use { response ->
             if (!response.isSuccessful) {
-                throw IOException("下载上传文件失败，HTTP 状态码：${response.code}")
+                throw HttpStatusException.fromResponse(response)
             }
             response.body.byteStream().use { input ->
                 return ShaUtils.hashSha256ToHex(input.readAllBytes())

--- a/commands/minecraft/src/main/java/top/chiloven/lukosbot2/commands/bot/motd/MotdQueryService.kt
+++ b/commands/minecraft/src/main/java/top/chiloven/lukosbot2/commands/bot/motd/MotdQueryService.kt
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.LogManager
 import org.springframework.stereotype.Service
 import top.chiloven.lukosbot2.Constants
 import top.chiloven.lukosbot2.config.ProxyConfigProp
+import top.chiloven.lukosbot2.util.HttpStatusException
 import top.chiloven.lukosbot2.util.JsonUtils
 import top.chiloven.lukosbot2.util.OkHttpUtils
 import java.io.IOException
@@ -94,7 +95,10 @@ class MotdQueryService(
             val body = response.body.string().trim()
             if (!response.isSuccessful) {
                 val detail = body.ifBlank { response.message.ifBlank { "HTTP ${response.code}" } }
-                throw IOException("mcsrvstat.us 查询失败（HTTP ${response.code}）：$detail")
+                throw HttpStatusException.fromResponse(
+                    response = response,
+                    responseBodySnippet = detail,
+                )
             }
             if (body.isBlank()) {
                 throw IOException("mcsrvstat.us 没有返回可用内容")

--- a/commands/minecraft/src/main/java/top/chiloven/lukosbot2/util/feature/MojangApi.kt
+++ b/commands/minecraft/src/main/java/top/chiloven/lukosbot2/util/feature/MojangApi.kt
@@ -35,7 +35,7 @@ object MojangApi {
     @JvmStatic
     @Throws(IOException::class)
     fun getUuidFromName(name: String): String? =
-        HttpJson.getObject("https://api.mojang.com/users/profiles/minecraft/$name")
+        HttpJson.getObjectResponse("https://api.mojang.com/users/profiles/minecraft/$name").body
             .get("id")
             .asString()
 
@@ -46,7 +46,7 @@ object MojangApi {
     @JvmStatic
     @Throws(IOException::class)
     fun getNameFromUuid(uuid: String): String? =
-        HttpJson.getObject("https://api.minecraftservices.com/minecraft/profile/lookup/$uuid")
+        HttpJson.getObjectResponse("https://api.minecraftservices.com/minecraft/profile/lookup/$uuid").body
             .get("name")
             .asString()
 
@@ -59,7 +59,7 @@ object MojangApi {
     fun getMcPlayerInfo(data: String): McPlayer {
         val uuid = if (data.length <= 16) getUuidFromName(data) else data
         val info: ObjectNode =
-            HttpJson.getObject("https://sessionserver.mojang.com/session/minecraft/profile/$uuid")
+            HttpJson.getObjectResponse("https://sessionserver.mojang.com/session/minecraft/profile/$uuid").body
         val value: ObjectNode = b64.decodeToJsonObject(getStringByPath(info, "properties[0].value", ""))
 
         return McPlayer(

--- a/commands/translate/build.gradle.kts
+++ b/commands/translate/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation(project(":core:model"))
     implementation(project(":properties"))
     implementation(project(":shared"))
+    implementation(project(":infrastructure:http"))
 
     implementation(libs.docker.java)
     implementation(libs.docker.java.transport.httpclient5)

--- a/commands/translate/src/main/java/top/chiloven/lukosbot2/commands/bot/translate/TranslationService.java
+++ b/commands/translate/src/main/java/top/chiloven/lukosbot2/commands/bot/translate/TranslationService.java
@@ -29,18 +29,21 @@ import com.github.dockerjava.core.DefaultDockerClientConfig;
 import com.github.dockerjava.core.DockerClientImpl;
 import com.github.dockerjava.httpclient5.ApacheDockerHttpClient;
 import com.github.dockerjava.transport.DockerHttpClient;
+import okhttp3.FormBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
 import tools.jackson.databind.node.ObjectNode;
 import top.chiloven.lukosbot2.config.CommandConfigProp.Translate;
-import top.chiloven.lukosbot2.util.StringUtils;
+import top.chiloven.lukosbot2.util.HttpStatusException;
+import top.chiloven.lukosbot2.util.HttpText;
+import top.chiloven.lukosbot2.util.OkHttpUtils;
 
 import java.io.IOException;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 import static top.chiloven.lukosbot2.util.JsonUtils.MAPPER;
 
@@ -54,7 +57,7 @@ public class TranslationService {
     private final String baseUrl;
     private final String defaultLang;
 
-    private final HttpClient httpClient;
+    private final OkHttpClient httpClient;
     private final DockerClient dockerClient;
 
     public TranslationService(Translate translate) {
@@ -71,8 +74,10 @@ public class TranslationService {
             ensureLibreTranslateContainer();
         }
 
-        this.httpClient = HttpClient.newBuilder()
-                .connectTimeout(Duration.ofSeconds(5))
+        this.httpClient = OkHttpUtils.newBuilder()
+                .connectTimeout(5, TimeUnit.SECONDS)
+                .readTimeout(30, TimeUnit.SECONDS)
+                .callTimeout(30, TimeUnit.SECONDS)
                 .build();
     }
 
@@ -155,27 +160,25 @@ public class TranslationService {
         String tgt = (to == null || to.isBlank()) ? defaultLang : to;
 
         try {
-            String body = "q=" + StringUtils.encodeTo(text)
-                    + "&source=" + StringUtils.encodeTo(src)
-                    + "&target=" + StringUtils.encodeTo(tgt)
-                    + "&format=text";
-
-            HttpRequest req = HttpRequest.newBuilder()
-                    .uri(URI.create(baseUrl + "/translate"))
-                    .header("Content-Type", "application/x-www-form-urlencoded")
-                    .timeout(Duration.ofSeconds(30))
-                    .POST(HttpRequest.BodyPublishers.ofString(body))
+            FormBody body = new FormBody.Builder()
+                    .add("q", text)
+                    .add("source", src)
+                    .add("target", tgt)
+                    .add("format", "text")
                     .build();
 
-            HttpResponse<String> resp = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
+            Request req = new Request.Builder()
+                    .url(baseUrl + "/translate")
+                    .header("Accept", "application/json")
+                    .post(body)
+                    .build();
 
-            if (resp.statusCode() != 200) {
-                return "翻译失败（HTTP " + resp.statusCode() + "）：" + resp.body();
-            }
-
-            return extractTranslatedText(resp.body());
-        } catch (IOException | InterruptedException e) {
-            Thread.currentThread().interrupt();
+            String responseBody = HttpText.sendStringResponse(httpClient, req, 30_000).getBody();
+            return extractTranslatedText(responseBody);
+        } catch (HttpStatusException e) {
+            return "翻译失败（HTTP " + e.getStatusCode() + "）："
+                    + Objects.toString(e.getResponseBodySnippet(), "");
+        } catch (IOException e) {
             return "翻译失败：" + e.getMessage();
         }
     }

--- a/commands/web/src/main/java/top/chiloven/lukosbot2/commands/bot/wikis/McWikiCommand.kt
+++ b/commands/web/src/main/java/top/chiloven/lukosbot2/commands/bot/wikis/McWikiCommand.kt
@@ -18,7 +18,6 @@
 package top.chiloven.lukosbot2.commands.bot.wikis
 
 import org.apache.logging.log4j.LogManager
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Service
@@ -31,6 +30,7 @@ import top.chiloven.lukosbot2.core.model.message.media.BytesRef
 import top.chiloven.lukosbot2.core.model.message.outbound.OutFile
 import top.chiloven.lukosbot2.core.model.message.outbound.OutImage
 import top.chiloven.lukosbot2.core.model.message.outbound.OutboundMessage
+import top.chiloven.lukosbot2.util.JsoupHttp
 import top.chiloven.lukosbot2.util.feature.WebScreenshot
 import top.chiloven.lukosbot2.util.feature.WebToMarkdown
 import java.time.Duration
@@ -161,10 +161,11 @@ class McWikiCommand : IWikiishCommand {
     )
 
     private fun fetchTitleAndLead(url: String): TitleLead {
-        val doc = Jsoup.connect(url)
-            .userAgent("Mozilla/5.0 (compatible; ${Constants.UA})")
-            .timeout(Duration.ofSeconds(15).toMillis().toInt())
-            .get()
+        val doc = JsoupHttp.getDocument(
+            url = url,
+            userAgent = "Mozilla/5.0 (compatible; ${Constants.UA})",
+            timeoutMs = Duration.ofSeconds(15).toMillis().toInt(),
+        )
 
         val title = doc.selectFirst("h1#firstHeading").textOrEmpty()
         val container =

--- a/core/runtime/src/main/java/top/chiloven/lukosbot2/core/MediaRefLoader.java
+++ b/core/runtime/src/main/java/top/chiloven/lukosbot2/core/MediaRefLoader.java
@@ -39,7 +39,7 @@ public class MediaRefLoader {
             return new LoadedPlatformMedia(bytes, name, mime);
         }
         if (ref instanceof UrlRef(String url)) {
-            var remote = HttpBytes.get(url);
+            var remote = HttpBytes.getResponse(url).getBody();
             return new LoadedPlatformMedia(remote.getBytes(), remote.getFileName(), remote.getMime());
         }
         if (ref instanceof PlatformFileRef platformFileRef) {

--- a/infrastructure/http/src/main/java/top/chiloven/lukosbot2/config/ProxyConfigProp.kt
+++ b/infrastructure/http/src/main/java/top/chiloven/lukosbot2/config/ProxyConfigProp.kt
@@ -184,6 +184,10 @@ data class ProxyConfigProp(
     /**
      * Apply proxy configuration to JDK [HttpClient].
      */
+    @Deprecated(
+        message = "Prefer OkHttpUtils.newBuilder() for project HTTP calls.",
+        replaceWith = ReplaceWith("OkHttpUtils.newBuilder(this)", "top.chiloven.lukosbot2.util.OkHttpUtils")
+    )
     fun applyTo(b: HttpClient.Builder?): HttpClient.Builder {
         val builder = b ?: HttpClient.newBuilder()
         if (!hasValidEndpoint()) return builder

--- a/infrastructure/http/src/main/java/top/chiloven/lukosbot2/util/HttpBytes.kt
+++ b/infrastructure/http/src/main/java/top/chiloven/lukosbot2/util/HttpBytes.kt
@@ -68,7 +68,7 @@ import java.util.concurrent.TimeUnit
  * ## Failure behavior
  *
  * - Transport problems raise [IOException].
- * - HTTP status codes outside the success range raise [IOException].
+ * - HTTP status codes outside the success range raise [HttpStatusException].
  * - Missing filename or MIME information is represented as `null` instead of causing failure.
  *
  * @author Chiloven945
@@ -135,7 +135,25 @@ object HttpBytes {
     @JvmStatic
     @JvmOverloads
     @Throws(IOException::class)
-    fun get(url: String, timeoutMs: Int = DEFAULT_TIMEOUT_MS): BytePayload {
+    @Deprecated(
+        message = "Use getResponse() when callers need HTTP status, headers, or final URL metadata.",
+        replaceWith = ReplaceWith("getResponse(url, timeoutMs).body")
+    )
+    fun get(url: String, timeoutMs: Int = DEFAULT_TIMEOUT_MS): BytePayload =
+        getResponse(url, timeoutMs).body
+
+    /**
+     * Execute an HTTP GET request and return the response body plus HTTP metadata.
+     *
+     * @param url request URL
+     * @param timeoutMs per-call timeout in milliseconds
+     * @return buffered response payload, status code, final URL, and response headers
+     * @throws IOException if the request fails or the server returns a non-success HTTP status
+     */
+    @JvmStatic
+    @JvmOverloads
+    @Throws(IOException::class)
+    fun getResponse(url: String, timeoutMs: Int = DEFAULT_TIMEOUT_MS): HttpCallResult<BytePayload> {
         val callClient = if (timeoutMs == DEFAULT_TIMEOUT_MS) client else client.newBuilder()
             .callTimeout(timeoutMs.toLong(), TimeUnit.MILLISECONDS)
             .build()
@@ -148,16 +166,23 @@ object HttpBytes {
 
         callClient.newCall(req).execute().use { resp ->
             if (!resp.isSuccessful) {
-                throw IOException("HTTP ${resp.code} while fetching binary: $url")
+                throw HttpStatusException.fromResponse(resp)
             }
+
             val mime = resp.header("Content-Type")
                 ?.substringBefore(';')
                 ?.trim()
                 ?.ifBlank { null }
             val fileName = parseFileName(resp.header("Content-Disposition")) ?: PathUtils.inferFileNameFromUrl(url)
             val bytes = resp.body.bytes()
+
             log.debug("Fetched {} bytes from {}", bytes.size, url)
-            return BytePayload(bytes = bytes, mime = mime, fileName = fileName)
+            return HttpCallResult(
+                body = BytePayload(bytes = bytes, mime = mime, fileName = fileName),
+                statusCode = resp.code,
+                url = resp.request.url.toString(),
+                headers = resp.headers.toMultimap(),
+            )
         }
     }
 

--- a/infrastructure/http/src/main/java/top/chiloven/lukosbot2/util/HttpCallResult.kt
+++ b/infrastructure/http/src/main/java/top/chiloven/lukosbot2/util/HttpCallResult.kt
@@ -15,12 +15,14 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package top.chiloven.lukosbot2.util.download
+package top.chiloven.lukosbot2.util
 
-import java.io.IOException
-
-internal class HttpStatusException(
+/**
+ * Successful HTTP response wrapper that keeps the parsed body together with transport metadata.
+ */
+data class HttpCallResult<T>(
+    val body: T,
     val statusCode: Int,
-    val retryAfterMs: Long?,
-    message: String,
-) : IOException(message)
+    val url: String,
+    val headers: Map<String, List<String>>,
+)

--- a/infrastructure/http/src/main/java/top/chiloven/lukosbot2/util/HttpJson.kt
+++ b/infrastructure/http/src/main/java/top/chiloven/lukosbot2/util/HttpJson.kt
@@ -85,7 +85,7 @@ import java.util.zip.InflaterInputStream
  * ## Failure behavior
  *
  * - Transport problems raise [IOException].
- * - HTTP status codes `>= 400` raise [IOException].
+ * - HTTP status codes `>= 400` raise [HttpStatusException].
  * - If the error body is JSON and contains fields such as `message`, `error`, or `detail`, the
  *   extracted text is used as the exception message.
  * - If a method expects an object/array root but the parsed JSON root has another type,
@@ -233,7 +233,7 @@ object HttpJson {
      * - The body is decoded using [decodeByContentEncoding].
      * - Text decoding uses the charset extracted from `Content-Type`, or UTF-8 as fallback.
      * - The final text is parsed with [MAPPER.readTree].
-     * - HTTP status codes `>= 400` throw [IOException], using a best-effort message extracted from
+     * - HTTP status codes `>= 400` throw [HttpStatusException], using a best-effort message extracted from
      *   the JSON body when possible.
      *
      * @param uri base request URI
@@ -246,12 +246,36 @@ object HttpJson {
      */
     @Throws(IOException::class)
     @JvmOverloads
+    @Deprecated(
+        message = "Use getAnyResponse() when callers need HTTP status, headers, or final URL metadata.",
+        replaceWith = ReplaceWith("getAnyResponse(uri, params, headers, readTimeoutMs).body")
+    )
     fun getAny(
         uri: URI,
         params: Map<String, String?>? = null,
         headers: Map<String, String>? = DEFAULT_HEADERS,
         readTimeoutMs: Int = DEFAULT_READ_TIMEOUT
-    ): JsonNode {
+    ): JsonNode = getAnyResponse(uri, params, headers, readTimeoutMs).body
+
+    /**
+     * Execute an HTTP GET request, parse the response as JSON, and keep HTTP response metadata.
+     *
+     * @param uri base request URI
+     * @param params optional query parameters; entries with `null` values are skipped
+     * @param headers optional additional request headers; defaults to [DEFAULT_HEADERS]
+     * @param readTimeoutMs per-call timeout in milliseconds
+     * @return parsed JSON root node plus status code, final URL, and response headers
+     * @throws IOException if the URL is invalid, the request fails, the response is not valid JSON,
+     * or the server returns an HTTP error status
+     */
+    @Throws(IOException::class)
+    @JvmOverloads
+    fun getAnyResponse(
+        uri: URI,
+        params: Map<String, String?>? = null,
+        headers: Map<String, String>? = DEFAULT_HEADERS,
+        readTimeoutMs: Int = DEFAULT_READ_TIMEOUT
+    ): HttpCallResult<JsonNode> {
         val t0 = System.currentTimeMillis()
         log.debug("Passed in a JSON HTTP request. uri={} param={} headers={}", uri, params, headers)
 
@@ -292,21 +316,36 @@ object HttpJson {
                 String(plain, StandardCharsets.UTF_8)
             }
 
-            val root: JsonNode = try {
+            val root: JsonNode? = try {
                 MAPPER.readTree(body)
-            } catch (e: Exception) {
-                if (code >= 400) throw IOException("HTTP $code")
-                throw IOException("Response is not valid JSON", e)
+            } catch (_: Exception) {
+                null
             }
 
-            if (code >= 400) throw IOException(extractErrorMessage(root, code))
+            if (code >= 400) {
+                val extracted = extractErrorMessage(root, code)
+                val snippet = if (extracted == "HTTP $code") body.take(4096).ifBlank { extracted } else extracted
+                throw HttpStatusException.fromResponse(
+                    response = resp,
+                    responseBodySnippet = snippet,
+                )
+            }
+
+            if (root == null) {
+                throw IOException("Response is not valid JSON")
+            }
 
             log.debug(
                 "Result received after {} seconds: {}",
                 (System.currentTimeMillis() - t0) / 1000,
                 MAPPER.writeValueAsString(root).truncate()
             )
-            return root
+            return HttpCallResult(
+                body = root,
+                statusCode = code,
+                url = resp.request.url.toString(),
+                headers = resp.headers.toMultimap(),
+            )
         }
     }
 
@@ -323,12 +362,25 @@ object HttpJson {
      */
     @JvmOverloads
     @Throws(IOException::class)
+    @Deprecated(
+        message = "Use getAnyResponse() when callers need HTTP status, headers, or final URL metadata.",
+        replaceWith = ReplaceWith("getAnyResponse(uri, params, headers, readTimeoutMs).body")
+    )
     fun getAny(
         uri: String,
         params: Map<String, String?>? = null,
         headers: Map<String, String>? = DEFAULT_HEADERS,
         readTimeoutMs: Int = DEFAULT_READ_TIMEOUT
-    ): JsonNode = getAny(URI(uri), params, headers, readTimeoutMs)
+    ): JsonNode = getAnyResponse(URI(uri), params, headers, readTimeoutMs).body
+
+    @JvmOverloads
+    @Throws(IOException::class)
+    fun getAnyResponse(
+        uri: String,
+        params: Map<String, String?>? = null,
+        headers: Map<String, String>? = DEFAULT_HEADERS,
+        readTimeoutMs: Int = DEFAULT_READ_TIMEOUT
+    ): HttpCallResult<JsonNode> = getAnyResponse(URI(uri), params, headers, readTimeoutMs)
 
     /**
      * Execute an HTTP GET request and require the JSON root to be an object.
@@ -345,16 +397,35 @@ object HttpJson {
      * @throws IllegalArgumentException if the JSON root exists but is not an object
      */
     @Throws(IOException::class)
+    @Deprecated(
+        message = "Use getObjectResponse() when callers need HTTP status, headers, or final URL metadata.",
+        replaceWith = ReplaceWith("getObjectResponse(uri, params, headers, readTimeoutMs).body")
+    )
     fun getObject(
         uri: URI,
         params: Map<String, String?>? = null,
         headers: Map<String, String>? = DEFAULT_HEADERS,
         readTimeoutMs: Int = DEFAULT_READ_TIMEOUT
-    ): ObjectNode {
-        val root = getAny(uri, params, headers, readTimeoutMs)
-        return root.asObjectOpt().orElseThrow {
+    ): ObjectNode = getObjectResponse(uri, params, headers, readTimeoutMs).body
+
+    @Throws(IOException::class)
+    fun getObjectResponse(
+        uri: URI,
+        params: Map<String, String?>? = null,
+        headers: Map<String, String>? = DEFAULT_HEADERS,
+        readTimeoutMs: Int = DEFAULT_READ_TIMEOUT
+    ): HttpCallResult<ObjectNode> {
+        val result = getAnyResponse(uri, params, headers, readTimeoutMs)
+        val root = result.body
+        val obj = root.asObjectOpt().orElseThrow {
             IllegalArgumentException("Response JSON is not an object (it is ${typeOf(root)})")
         }
+        return HttpCallResult(
+            body = obj,
+            statusCode = result.statusCode,
+            url = result.url,
+            headers = result.headers,
+        )
     }
 
     /**
@@ -370,12 +441,25 @@ object HttpJson {
      */
     @JvmStatic
     @Throws(IOException::class)
+    @Deprecated(
+        message = "Use getObjectResponse() when callers need HTTP status, headers, or final URL metadata.",
+        replaceWith = ReplaceWith("getObjectResponse(uri, params, headers, readTimeoutMs).body")
+    )
     fun getObject(
         uri: String,
         params: Map<String, String?>? = null,
         headers: Map<String, String>? = DEFAULT_HEADERS,
         readTimeoutMs: Int = DEFAULT_READ_TIMEOUT
-    ): ObjectNode = getObject(URI(uri), params, headers, readTimeoutMs)
+    ): ObjectNode = getObjectResponse(URI(uri), params, headers, readTimeoutMs).body
+
+    @JvmStatic
+    @Throws(IOException::class)
+    fun getObjectResponse(
+        uri: String,
+        params: Map<String, String?>? = null,
+        headers: Map<String, String>? = DEFAULT_HEADERS,
+        readTimeoutMs: Int = DEFAULT_READ_TIMEOUT
+    ): HttpCallResult<ObjectNode> = getObjectResponse(URI(uri), params, headers, readTimeoutMs)
 
     /**
      * Execute an HTTP GET request and require the JSON root to be an array.
@@ -392,16 +476,35 @@ object HttpJson {
      * @throws IllegalArgumentException if the JSON root exists but is not an array
      */
     @Throws(IOException::class)
+    @Deprecated(
+        message = "Use getArrayResponse() when callers need HTTP status, headers, or final URL metadata.",
+        replaceWith = ReplaceWith("getArrayResponse(uri, params, headers, readTimeoutMs).body")
+    )
     fun getArray(
         uri: URI,
         params: Map<String, String?>? = null,
         headers: Map<String, String>? = DEFAULT_HEADERS,
         readTimeoutMs: Int = DEFAULT_READ_TIMEOUT
-    ): ArrayNode {
-        val root = getAny(uri, params, headers, readTimeoutMs)
-        return root.asArrayOpt().orElseThrow {
+    ): ArrayNode = getArrayResponse(uri, params, headers, readTimeoutMs).body
+
+    @Throws(IOException::class)
+    fun getArrayResponse(
+        uri: URI,
+        params: Map<String, String?>? = null,
+        headers: Map<String, String>? = DEFAULT_HEADERS,
+        readTimeoutMs: Int = DEFAULT_READ_TIMEOUT
+    ): HttpCallResult<ArrayNode> {
+        val result = getAnyResponse(uri, params, headers, readTimeoutMs)
+        val root = result.body
+        val arr = root.asArrayOpt().orElseThrow {
             IllegalArgumentException("Response JSON is not an array (it is ${typeOf(root)})")
         }
+        return HttpCallResult(
+            body = arr,
+            statusCode = result.statusCode,
+            url = result.url,
+            headers = result.headers,
+        )
     }
 
     /**
@@ -416,14 +519,24 @@ object HttpJson {
      * @throws IllegalArgumentException if the JSON root exists but is not an array
      */
     @Throws(IOException::class)
+    @Deprecated(
+        message = "Use getArrayResponse() when callers need HTTP status, headers, or final URL metadata.",
+        replaceWith = ReplaceWith("getArrayResponse(uri, params, headers, readTimeoutMs).body")
+    )
     fun getArray(
         uri: String,
         params: Map<String, String?>? = null,
         headers: Map<String, String>? = DEFAULT_HEADERS,
         readTimeoutMs: Int = DEFAULT_READ_TIMEOUT
-    ): ArrayNode {
-        return getArray(URI(uri), params, headers, readTimeoutMs)
-    }
+    ): ArrayNode = getArrayResponse(URI(uri), params, headers, readTimeoutMs).body
+
+    @Throws(IOException::class)
+    fun getArrayResponse(
+        uri: String,
+        params: Map<String, String?>? = null,
+        headers: Map<String, String>? = DEFAULT_HEADERS,
+        readTimeoutMs: Int = DEFAULT_READ_TIMEOUT
+    ): HttpCallResult<ArrayNode> = getArrayResponse(URI(uri), params, headers, readTimeoutMs)
 
     /**
      * Build a URL query string from a key/value map.

--- a/infrastructure/http/src/main/java/top/chiloven/lukosbot2/util/HttpStatusException.kt
+++ b/infrastructure/http/src/main/java/top/chiloven/lukosbot2/util/HttpStatusException.kt
@@ -1,0 +1,149 @@
+/*
+ * Copyright © 2026 Chiloven945
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package top.chiloven.lukosbot2.util
+
+import okhttp3.Response
+import java.io.IOException
+import java.time.Duration
+import java.time.Instant
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import kotlin.math.max
+
+/**
+ * Structured exception for HTTP responses whose status code is outside the expected success range.
+ *
+ * Transport-level failures such as DNS, TLS, socket timeout or interrupted reads should continue to
+ * surface as plain [IOException] or a subtype. This exception means an HTTP response was received and
+ * its status code can be inspected safely by callers.
+ */
+open class HttpStatusException @JvmOverloads constructor(
+    val statusCode: Int,
+    val method: String? = null,
+    val url: String? = null,
+    val responseBodySnippet: String? = null,
+    val retryAfterMs: Long? = null,
+    val responseHeaders: Map<String, List<String>> = emptyMap(),
+    message: String = buildMessage(statusCode, method, url, responseBodySnippet),
+    cause: Throwable? = null,
+) : IOException(message, cause) {
+
+    val retryable: Boolean
+        get() = isRetryableStatus(statusCode)
+
+    companion object {
+
+        @JvmStatic
+        @JvmOverloads
+        fun fromResponse(
+            response: Response,
+            responseBodySnippet: String? = runCatching { response.peekBody(4096).string() }.getOrNull(),
+            message: String? = null,
+            cause: Throwable? = null,
+        ): HttpStatusException {
+            val method = response.request.method
+            val url = response.request.url.toString()
+            return HttpStatusException(
+                statusCode = response.code,
+                method = method,
+                url = url,
+                responseBodySnippet = responseBodySnippet,
+                retryAfterMs = parseRetryAfterMs(response.header("Retry-After")),
+                responseHeaders = response.headers.toMultimap(),
+                message = message ?: buildMessage(response.code, method, url, responseBodySnippet),
+                cause = cause,
+            )
+        }
+
+        @JvmStatic
+        @JvmOverloads
+        fun fromStatus(
+            statusCode: Int,
+            method: String? = null,
+            url: String? = null,
+            responseBodySnippet: String? = null,
+            retryAfterHeader: String? = null,
+            responseHeaders: Map<String, List<String>> = emptyMap(),
+            message: String? = null,
+            cause: Throwable? = null,
+        ): HttpStatusException = HttpStatusException(
+            statusCode = statusCode,
+            method = method,
+            url = url,
+            responseBodySnippet = responseBodySnippet,
+            retryAfterMs = parseRetryAfterMs(retryAfterHeader),
+            responseHeaders = responseHeaders,
+            message = message ?: buildMessage(statusCode, method, url, responseBodySnippet),
+            cause = cause,
+        )
+
+        @JvmStatic
+        fun isRetryableStatus(code: Int): Boolean =
+            code == 408 || code == 429 || code in 500..599
+
+        private fun parseRetryAfterMs(value: String?): Long? {
+            if (value.isNullOrBlank()) return null
+
+            value.trim().toLongOrNull()?.let { seconds ->
+                if (seconds > 0) return seconds * 1000L
+            }
+
+            return try {
+                val zdt = ZonedDateTime.parse(value.trim(), DateTimeFormatter.RFC_1123_DATE_TIME)
+                max(0L, Duration.between(Instant.now(), zdt.toInstant()).toMillis())
+            } catch (_: Exception) {
+                null
+            }
+        }
+
+        private fun buildMessage(
+            statusCode: Int,
+            method: String?,
+            url: String?,
+            snippet: String?,
+        ): String = buildString {
+            append("HTTP ").append(statusCode)
+            if (!method.isNullOrBlank()) append(' ').append(method)
+            if (!url.isNullOrBlank()) append(' ').append(url)
+            if (!snippet.isNullOrBlank()) {
+                append(": ").append(snippet.lineSequence().firstOrNull().orEmpty())
+            }
+        }
+
+        @JvmStatic
+        @JvmOverloads
+        fun message(e: Throwable, defaultAction: String = "请求失败"): String = when (e) {
+            is HttpStatusException -> when (e.statusCode) {
+                400 -> "$defaultAction：请求参数无效。"
+                401, 403 -> "$defaultAction：远端拒绝访问或凭据无效。"
+                404 -> "$defaultAction：资源不存在。"
+                408 -> "$defaultAction：远端响应超时。"
+                429 -> "$defaultAction：请求过于频繁，请稍后再试。"
+                in 500..599 -> "$defaultAction：远端服务暂时不可用。"
+                else -> "$defaultAction：HTTP ${e.statusCode}。"
+            }
+
+            else -> e.message?.takeIf { it.isNotBlank() } ?: "$defaultAction，请稍后再试。"
+        }
+
+        fun HttpStatusException.friendly(defaultAction: String = "请求失败"): String =
+            message(this, defaultAction)
+
+    }
+
+}

--- a/infrastructure/http/src/main/java/top/chiloven/lukosbot2/util/HttpText.kt
+++ b/infrastructure/http/src/main/java/top/chiloven/lukosbot2/util/HttpText.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2026 Chiloven945
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package top.chiloven.lukosbot2.util
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import top.chiloven.lukosbot2.Constants
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+/**
+ * Lightweight OkHttp helper for text responses that are not covered by [HttpJson] or [HttpBytes].
+ *
+ * Typical use cases are form POST endpoints, token endpoints, and APIs whose success body needs to
+ * be inspected as plain text before the caller parses it. HTTP non-success statuses are reported as
+ * [HttpStatusException] so callers can inspect structured status metadata instead of parsing an
+ * exception message.
+ */
+object HttpText {
+
+    private const val DEFAULT_TIMEOUT_MS: Int = 30_000
+    private val UA: String = "Mozilla/5.0 (compatible; ${Constants.UA})"
+
+    private val clientCache = OkHttpUtils.ProxyAwareOkHttpClientCache(
+        connectTimeoutMs = 10_000,
+        readTimeoutMs = DEFAULT_TIMEOUT_MS.toLong(),
+        callTimeoutMs = DEFAULT_TIMEOUT_MS.toLong(),
+    )
+
+    private val client: OkHttpClient
+        get() = clientCache.client
+
+    @JvmStatic
+    @JvmOverloads
+    @Throws(IOException::class)
+    fun sendStringResponse(
+        request: Request,
+        timeoutMs: Int = DEFAULT_TIMEOUT_MS,
+        expected: IntRange = 200..299,
+    ): HttpCallResult<String> = sendStringResponse(client, request, timeoutMs, expected)
+
+    @JvmStatic
+    @JvmOverloads
+    @Throws(IOException::class)
+    fun sendStringResponse(
+        client: OkHttpClient,
+        request: Request,
+        timeoutMs: Int = DEFAULT_TIMEOUT_MS,
+        expected: IntRange = 200..299,
+    ): HttpCallResult<String> {
+        val callClient = if (timeoutMs == DEFAULT_TIMEOUT_MS) {
+            client
+        } else {
+            client.newBuilder()
+                .callTimeout(timeoutMs.toLong(), TimeUnit.MILLISECONDS)
+                .readTimeout(timeoutMs.toLong(), TimeUnit.MILLISECONDS)
+                .build()
+        }
+
+        val req = if (request.header("User-Agent") == null) {
+            request.newBuilder().header("User-Agent", UA).build()
+        } else {
+            request
+        }
+
+        callClient.newCall(req).execute().use { resp ->
+            val body = resp.body.string()
+            if (resp.code !in expected) {
+                throw HttpStatusException.fromResponse(
+                    response = resp,
+                    responseBodySnippet = body.take(4096),
+                )
+            }
+
+            return HttpCallResult(
+                body = body,
+                statusCode = resp.code,
+                url = resp.request.url.toString(),
+                headers = resp.headers.toMultimap(),
+            )
+        }
+    }
+
+}

--- a/infrastructure/http/src/main/java/top/chiloven/lukosbot2/util/download/RangeDownloader.kt
+++ b/infrastructure/http/src/main/java/top/chiloven/lukosbot2/util/download/RangeDownloader.kt
@@ -19,6 +19,7 @@ package top.chiloven.lukosbot2.util.download
 
 import okhttp3.Response
 import org.apache.logging.log4j.LogManager
+import top.chiloven.lukosbot2.util.HttpStatusException
 import top.chiloven.lukosbot2.util.PathUtils
 import top.chiloven.lukosbot2.util.concurrent.Coroutines
 import java.io.IOException
@@ -317,11 +318,7 @@ internal class RangeDownloader(
                     http.debugResponseSummary(url, code, response.headers, true, part.start)
 
                     if (code >= 400) {
-                        throw HttpStatusException(
-                            statusCode = code,
-                            retryAfterMs = RetryPolicy.parseRetryAfterMs(response.header("Retry-After")),
-                            message = "HTTP $code"
-                        )
+                        throw HttpStatusException.fromResponse(response)
                     }
                     if (code != 206) {
                         throw IOException("Expected HTTP 206, got HTTP $code")

--- a/infrastructure/http/src/main/java/top/chiloven/lukosbot2/util/download/RetryPolicy.kt
+++ b/infrastructure/http/src/main/java/top/chiloven/lukosbot2/util/download/RetryPolicy.kt
@@ -17,12 +17,9 @@
  */
 package top.chiloven.lukosbot2.util.download
 
+import top.chiloven.lukosbot2.util.HttpStatusException
 import java.io.IOException
 import java.nio.file.FileSystemException
-import java.time.Duration
-import java.time.Instant
-import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
 import java.util.concurrent.ThreadLocalRandom
 import kotlin.math.max
 import kotlin.math.min
@@ -37,7 +34,7 @@ internal data class RetryPolicy(
     fun maxAttempts(): Int = 1 + max(0, maxRetries)
 
     fun shouldRetry(error: IOException): Boolean = when (error) {
-        is HttpStatusException -> isRetryableStatus(error.statusCode)
+        is HttpStatusException -> error.retryable
         is FileSystemException -> false
         else -> true
     }
@@ -54,9 +51,6 @@ internal data class RetryPolicy(
         return min(retryAfterCapMs, delay + jitter)
     }
 
-    private fun isRetryableStatus(code: Int): Boolean =
-        code == 408 || code == 429 || code in 500..599
-
     companion object {
 
         fun default(maxRetries: Int): RetryPolicy = RetryPolicy(
@@ -65,20 +59,6 @@ internal data class RetryPolicy(
             maxDelayMs = DownloadDefaults.DEFAULT_RETRY_MAX_DELAY_MS,
             retryAfterCapMs = DownloadDefaults.DEFAULT_RETRY_AFTER_CAP_MS
         )
-
-        fun parseRetryAfterMs(value: String?): Long? {
-            if (value.isNullOrBlank()) return null
-            value.trim().toLongOrNull()?.let { seconds ->
-                if (seconds > 0) return seconds * 1000L
-            }
-
-            return try {
-                val zdt = ZonedDateTime.parse(value.trim(), DateTimeFormatter.RFC_1123_DATE_TIME)
-                max(0L, Duration.between(Instant.now(), zdt.toInstant()).toMillis())
-            } catch (_: Exception) {
-                null
-            }
-        }
 
         @Throws(IOException::class)
         fun sleepMs(ms: Long) {

--- a/infrastructure/http/src/main/java/top/chiloven/lukosbot2/util/download/SingleFileDownloader.kt
+++ b/infrastructure/http/src/main/java/top/chiloven/lukosbot2/util/download/SingleFileDownloader.kt
@@ -19,6 +19,7 @@ package top.chiloven.lukosbot2.util.download
 
 import okhttp3.Response
 import org.apache.logging.log4j.LogManager
+import top.chiloven.lukosbot2.util.HttpStatusException
 import top.chiloven.lukosbot2.util.PathUtils
 import java.io.IOException
 import java.net.URI
@@ -126,11 +127,7 @@ internal class SingleFileDownloader(
                             }
 
                             if (code >= 400) {
-                                throw HttpStatusException(
-                                    statusCode = code,
-                                    retryAfterMs = RetryPolicy.parseRetryAfterMs(response.header("Retry-After")),
-                                    message = "HTTP $code"
-                                )
+                                throw HttpStatusException.fromResponse(response)
                             }
 
                             writeResponseBody(

--- a/infrastructure/http/src/test/java/top/chiloven/lukosbot2/util/DownloadClientTest.kt
+++ b/infrastructure/http/src/test/java/top/chiloven/lukosbot2/util/DownloadClientTest.kt
@@ -20,7 +20,6 @@ package top.chiloven.lukosbot2.util
 import com.sun.net.httpserver.HttpExchange
 import com.sun.net.httpserver.HttpServer
 import org.junit.jupiter.api.Test
-import top.chiloven.lukosbot2.util.download.RetryPolicy
 import java.net.InetSocketAddress
 import java.net.URI
 import java.nio.charset.StandardCharsets
@@ -77,10 +76,10 @@ class DownloadClientTest {
     }
 
     @Test
-    fun `retry after parser supports seconds and RFC date`() {
-        val seconds = RetryPolicy.parseRetryAfterMs("1")
+    fun `HTTP status exception supports seconds and RFC date Retry-After`() {
+        val seconds = HttpStatusException.fromStatus(429, retryAfterHeader = "1").retryAfterMs
         val date = ZonedDateTime.now().plusSeconds(2).format(DateTimeFormatter.RFC_1123_DATE_TIME)
-        val dateDelay = RetryPolicy.parseRetryAfterMs(date)
+        val dateDelay = HttpStatusException.fromStatus(429, retryAfterHeader = date).retryAfterMs
 
         assertEquals(1_000L, seconds)
         assertNotNull(dateDelay)

--- a/infrastructure/http/src/test/java/top/chiloven/lukosbot2/util/HttpStatusHandlingTest.kt
+++ b/infrastructure/http/src/test/java/top/chiloven/lukosbot2/util/HttpStatusHandlingTest.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright © 2026 Chiloven945
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package top.chiloven.lukosbot2.util
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import okhttp3.FormBody
+import okhttp3.Request
+import org.junit.jupiter.api.Test
+import java.net.InetSocketAddress
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.Executors
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class HttpStatusHandlingTest {
+
+    @Test
+    fun `HttpBytes getResponse returns status and headers`() = withServer { server ->
+        server.context("/file") { exchange ->
+            exchange.responseHeaders.add("Content-Type", "text/plain; charset=utf-8")
+            exchange.responseHeaders.add("Content-Disposition", "attachment; filename=hello.txt")
+            exchange.sendText(200, "hello")
+        }
+
+        val result = HttpBytes.getResponse(server.uri("/file").toString())
+
+        assertEquals(200, result.statusCode)
+        assertEquals("hello", String(result.body.bytes, StandardCharsets.UTF_8))
+        assertEquals("text/plain", result.body.mime)
+        assertEquals("hello.txt", result.body.fileName)
+        assertTrue(result.headers.containsKey("Content-type") || result.headers.containsKey("Content-Type"))
+    }
+
+    @Test
+    fun `HttpBytes non success exposes structured status`() = withServer { server ->
+        server.context("/missing") { exchange ->
+            exchange.responseHeaders.add("Retry-After", "1")
+            exchange.sendText(429, "slow down")
+        }
+
+        val error = assertFailsWith<HttpStatusException> {
+            HttpBytes.getResponse(server.uri("/missing").toString())
+        }
+
+        assertEquals(429, error.statusCode)
+        assertEquals(1_000L, error.retryAfterMs)
+        assertTrue(error.retryable)
+        assertTrue(error.responseBodySnippet.orEmpty().contains("slow down"))
+    }
+
+    @Test
+    fun `HttpJson getObjectResponse returns status and JSON body`() = withServer { server ->
+        server.context("/json") { exchange -> exchange.sendJson(200, "{\"ok\":true}") }
+
+        val result = HttpJson.getObjectResponse(server.uri("/json"))
+
+        assertEquals(200, result.statusCode)
+        assertTrue(result.body.has("ok"))
+    }
+
+    @Test
+    fun `HttpJson non JSON error still exposes structured status and snippet`() = withServer { server ->
+        server.context("/boom") { exchange -> exchange.sendText(500, "temporary outage") }
+
+        val error = assertFailsWith<HttpStatusException> {
+            HttpJson.getObjectResponse(server.uri("/boom"))
+        }
+
+        assertEquals(500, error.statusCode)
+        assertTrue(error.retryable)
+        assertTrue(error.responseBodySnippet.orEmpty().contains("temporary outage"))
+    }
+
+
+    @Test
+    fun `HttpText sendStringResponse posts form and returns status`() = withServer { server ->
+        server.context("/form") { exchange ->
+            assertEquals("POST", exchange.requestMethod)
+            exchange.sendJson(200, "{\"ok\":true}")
+        }
+
+        val request = Request.Builder()
+            .url(server.uri("/form").toString())
+            .post(FormBody.Builder().add("q", "hello").build())
+            .build()
+
+        val result = HttpText.sendStringResponse(request)
+
+        assertEquals(200, result.statusCode)
+        assertTrue(result.body.contains("ok"))
+    }
+
+    @Test
+    fun `HttpText non success exposes structured status`() = withServer { server ->
+        server.context("/rate-limited") { exchange ->
+            exchange.responseHeaders.add("Retry-After", "3")
+            exchange.sendText(429, "slow down")
+        }
+
+        val request = Request.Builder()
+            .url(server.uri("/rate-limited").toString())
+            .get()
+            .build()
+
+        val error = assertFailsWith<HttpStatusException> {
+            HttpText.sendStringResponse(request)
+        }
+
+        assertEquals(429, error.statusCode)
+        assertEquals(3_000L, error.retryAfterMs)
+        assertTrue(error.responseBodySnippet.orEmpty().contains("slow down"))
+    }
+
+    @Test
+    fun `HttpStatusException parses Retry-After at exception boundary`() {
+        assertEquals(2_000L, HttpStatusException.fromStatus(429, retryAfterHeader = "2").retryAfterMs)
+        assertNotNull(
+            HttpStatusException.fromStatus(429, retryAfterHeader = "Wed, 21 Oct 2099 07:28:00 GMT").retryAfterMs
+        )
+    }
+
+    private fun withServer(block: (TestHttpServer) -> Unit) {
+        TestHttpServer().use { server -> block(server) }
+    }
+
+    private class TestHttpServer : AutoCloseable {
+
+        private val server: HttpServer = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        private val executor = Executors.newCachedThreadPool()
+
+        init {
+            server.executor = executor
+            server.start()
+        }
+
+        fun uri(path: String): URI = URI.create("http://127.0.0.1:${server.address.port}$path")
+
+        fun context(path: String, handler: (HttpExchange) -> Unit) {
+            server.createContext(path) { exchange -> handler(exchange) }
+        }
+
+        override fun close() {
+            server.stop(0)
+            executor.shutdownNow()
+        }
+    }
+}
+
+private fun HttpExchange.sendJson(code: Int, text: String) {
+    responseHeaders.add("Content-Type", "application/json; charset=utf-8")
+    sendText(code, text)
+}
+
+private fun HttpExchange.sendText(code: Int, text: String) {
+    val bytes = text.toByteArray(StandardCharsets.UTF_8)
+    responseHeaders.add("Content-Length", bytes.size.toString())
+    sendResponseHeaders(code, bytes.size.toLong())
+    responseBody.use { it.write(bytes) }
+}

--- a/infrastructure/web-infra/src/main/java/top/chiloven/lukosbot2/util/JsoupHttp.kt
+++ b/infrastructure/web-infra/src/main/java/top/chiloven/lukosbot2/util/JsoupHttp.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2026 Chiloven945
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package top.chiloven.lukosbot2.util
+
+import org.jsoup.Connection
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import java.io.IOException
+import java.net.Proxy
+
+/**
+ * Jsoup GET helper that turns non-2xx HTTP responses into [HttpStatusException].
+ */
+object JsoupHttp {
+
+    @JvmStatic
+    @JvmOverloads
+    @Throws(IOException::class)
+    fun getDocument(
+        url: String,
+        userAgent: String,
+        timeoutMs: Int,
+        proxy: Proxy? = null,
+        configure: (Connection) -> Unit = {},
+    ): Document {
+        val conn = Jsoup.connect(url)
+            .userAgent(userAgent)
+            .timeout(timeoutMs)
+            .ignoreHttpErrors(true)
+
+        if (proxy != null && proxy != Proxy.NO_PROXY) {
+            conn.proxy(proxy)
+        }
+        configure(conn)
+
+        val resp = conn.execute()
+        if (resp.statusCode() !in 200..299) {
+            throw HttpStatusException(
+                statusCode = resp.statusCode(),
+                method = "GET",
+                url = url,
+                responseBodySnippet = resp.body().take(4096),
+                responseHeaders = resp.headers().mapValues { listOf(it.value) },
+            )
+        }
+
+        return resp.parse()
+    }
+}

--- a/infrastructure/web-infra/src/main/java/top/chiloven/lukosbot2/util/feature/WebScreenshot.kt
+++ b/infrastructure/web-infra/src/main/java/top/chiloven/lukosbot2/util/feature/WebScreenshot.kt
@@ -18,7 +18,6 @@
 package top.chiloven.lukosbot2.util.feature
 
 import org.apache.logging.log4j.LogManager
-import org.jsoup.Jsoup
 import org.openqa.selenium.*
 import org.openqa.selenium.chrome.ChromeDriver
 import org.openqa.selenium.chrome.ChromeOptions
@@ -28,6 +27,7 @@ import top.chiloven.lukosbot2.Constants
 import top.chiloven.lukosbot2.config.ProxyConfigProp
 import top.chiloven.lukosbot2.core.model.ContentData
 import top.chiloven.lukosbot2.util.ImageUtils
+import top.chiloven.lukosbot2.util.JsoupHttp
 import top.chiloven.lukosbot2.util.PathUtils.sanitizeFileName
 import top.chiloven.lukosbot2.util.spring.SpringBeans
 import java.io.File
@@ -273,10 +273,11 @@ object WebScreenshot {
 
     private fun fetchMediaWikiTitle(url: String, fallback: String): String {
         return try {
-            val doc = Jsoup.connect(url)
-                .userAgent(USER_AGENT)
-                .timeout(10_000)
-                .get()
+            val doc = JsoupHttp.getDocument(
+                url = url,
+                userAgent = USER_AGENT,
+                timeoutMs = 10_000,
+            )
 
             doc.selectFirst("h1#firstHeading")
                 ?.text()

--- a/infrastructure/web-infra/src/main/java/top/chiloven/lukosbot2/util/feature/WebToMarkdown.kt
+++ b/infrastructure/web-infra/src/main/java/top/chiloven/lukosbot2/util/feature/WebToMarkdown.kt
@@ -18,11 +18,11 @@
 package top.chiloven.lukosbot2.util.feature
 
 import com.vladsch.flexmark.html2md.converter.FlexmarkHtmlConverter
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
 import top.chiloven.lukosbot2.Constants
 import top.chiloven.lukosbot2.config.ProxyConfigProp
 import top.chiloven.lukosbot2.core.model.ContentData
+import top.chiloven.lukosbot2.util.JsoupHttp
 import top.chiloven.lukosbot2.util.PathUtils.sanitizeFileName
 import top.chiloven.lukosbot2.util.spring.SpringBeans
 import java.net.Proxy
@@ -46,16 +46,13 @@ object WebToMarkdown {
     ): ContentData {
         val proxy = SpringBeans.getBean(ProxyConfigProp::class.java)
 
-        val conn = Jsoup.connect(url)
-            .userAgent(USER_AGENT)
-            .timeout(TIMEOUT_MS)
-
         val javaProxy: Proxy = proxy.toJavaProxy()
-        if (proxy.enabled && javaProxy != Proxy.NO_PROXY) {
-            conn.proxy(javaProxy)
-        }
-
-        val doc = conn.get()
+        val doc = JsoupHttp.getDocument(
+            url = url,
+            userAgent = USER_AGENT,
+            timeoutMs = TIMEOUT_MS,
+            proxy = javaProxy.takeIf { proxy.enabled && it != Proxy.NO_PROXY },
+        )
 
         val title = resolveTitle(docTitleFallback = defaultTitleBase, doc = doc, titleSelector = titleSelector)
         val filename = "${sanitizeFileName(title, fallback = defaultTitleBase ?: "page")}.md"

--- a/platform/telegram/src/main/java/top/chiloven/lukosbot2/platform/telegram/TelegramFileLoader.kt
+++ b/platform/telegram/src/main/java/top/chiloven/lukosbot2/platform/telegram/TelegramFileLoader.kt
@@ -41,15 +41,15 @@ class TelegramFileLoader(
             throw IOException("Telegram 配置不完整，无法读取图片。")
         }
 
-        val root = HttpJson.getObject(
+        val root = HttpJson.getObjectResponse(
             URI("https://api.telegram.org/bot$token/getFile"),
             mapOf("file_id" to ref.fileId())
-        )
+        ).body
         val filePath = root.path("result").path("file_path").asString(null)
             ?.takeIf { it.isNotBlank() }
             ?: throw IOException("Telegram 未返回文件路径。")
 
-        val remote = HttpBytes.get("https://api.telegram.org/file/bot$token/$filePath")
+        val remote = HttpBytes.getResponse("https://api.telegram.org/file/bot$token/$filePath").body
         return LoadedPlatformMedia(
             remote.bytes,
             remote.fileName ?: filePath.substringAfterLast('/').ifBlank { null },

--- a/platform/telegram/src/main/java/top/chiloven/lukosbot2/platform/telegram/TelegramStack.java
+++ b/platform/telegram/src/main/java/top/chiloven/lukosbot2/platform/telegram/TelegramStack.java
@@ -25,8 +25,11 @@ import org.telegram.telegrambots.meta.api.methods.send.SendDocument;
 import org.telegram.telegrambots.meta.api.methods.send.SendPhoto;
 import org.telegram.telegrambots.meta.api.objects.message.Message;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import top.chiloven.lukosbot2.util.HttpStatusException;
 
 import java.io.Serializable;
+import java.io.UncheckedIOException;
+import java.util.Collections;
 
 final class TelegramStack implements AutoCloseable {
 
@@ -75,15 +78,68 @@ final class TelegramStack implements AutoCloseable {
         try {
             return client.execute(method);
         } catch (TelegramApiException e) {
-            throw new RuntimeException(e);
+            throw wrapTelegramApiException(e);
         }
+    }
+
+    private static RuntimeException wrapTelegramApiException(TelegramApiException e) {
+        Integer statusCode = reflectInt(e, "getErrorCode", "getStatusCode", "getStatus");
+        if (statusCode == null) {
+            return new RuntimeException(e);
+        }
+
+        String snippet = reflectString(e, "getApiResponse", "getResponse", "getMessage");
+        return new UncheckedIOException(new HttpStatusException(
+                statusCode,
+                "POST",
+                "Telegram Bot API",
+                snippet,
+                null,
+                Collections.emptyMap(),
+                "Telegram Bot API HTTP " + statusCode + (snippet == null || snippet.isBlank() ? "" : ": " + snippet),
+                e
+        ));
+    }
+
+    private static Integer reflectInt(TelegramApiException e, String... methodNames) {
+        for (String name : methodNames) {
+            try {
+                var method = e.getClass().getMethod(name);
+                Object value = method.invoke(e);
+                if (value instanceof Number number) {
+                    return number.intValue();
+                }
+                if (value instanceof String text && !text.isBlank()) {
+                    return Integer.parseInt(text.trim());
+                }
+            } catch (Exception _) {
+                // Try the next known TelegramApiException accessor.
+            }
+        }
+        return null;
+    }
+
+    private static String reflectString(TelegramApiException e, String... methodNames) {
+        for (String name : methodNames) {
+            try {
+                var method = e.getClass().getMethod(name);
+                Object value = method.invoke(e);
+                if (value != null) {
+                    String text = value.toString();
+                    if (!text.isBlank()) return text;
+                }
+            } catch (Exception _) {
+                // Try the next known TelegramApiException accessor.
+            }
+        }
+        return e.getMessage();
     }
 
     Message execute(SendPhoto method) {
         try {
             return client.execute(method);
         } catch (TelegramApiException e) {
-            throw new RuntimeException(e);
+            throw wrapTelegramApiException(e);
         }
     }
 
@@ -91,7 +147,7 @@ final class TelegramStack implements AutoCloseable {
         try {
             return client.execute(method);
         } catch (TelegramApiException e) {
-            throw new RuntimeException(e);
+            throw wrapTelegramApiException(e);
         }
     }
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce a structured HttpStatusException and HttpCallResult abstraction across the HTTP stack, and update callers to use centralized OkHttp-based helpers with richer HTTP metadata and friendlier error handling.

Bug Fixes:
- Improve handling of non-2xx HTTP responses by converting ad-hoc IOException and RuntimeException usages into structured HttpStatusException failures.
- Ensure Jsoup-based HTML fetches and various external API calls surface HTTP status and body snippets consistently instead of generic failures.

Enhancements:
- Extend HttpJson and HttpBytes with response-returning variants that expose status code, final URL, and headers while deprecating body-only helpers.
- Introduce HttpText and JsoupHttp utilities to standardize OkHttp and Jsoup text/HTML requests with unified HTTP status handling.
- Refine retry logic to rely on HttpStatusException retryable semantics and centralized Retry-After parsing.
- Improve Telegram, Kemono, Bilibili, Minecraft MOTD, and other integration commands with more informative, user-friendly error messages based on HTTP status codes.
- Replace remaining JDK HttpClient usages in music and translation providers with OkHttp-based requests and shared HTTP utilities.
- Add logging for thumbnail loading failures in the E621 search grid renderer to aid debugging of image fetch issues.

Build:
- Wire the translate module to depend on the shared HTTP infrastructure module for reuse of HTTP utilities.

Tests:
- Add HttpStatusHandlingTest and extend existing tests to cover HttpStatusException Retry-After parsing and the new response-wrapping helpers.