### PR TITLE
refactor(build): fix gradle module dependency direction

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation(project(":core:command"))
     implementation(project(":platform:api"))
     implementation(project(":infrastructure:http"))
+    implementation(project(":infrastructure:jdbc"))
     implementation(project(":infrastructure:spring"))
 
     implementation(project(":platform:telegram"))

--- a/core/command/build.gradle.kts
+++ b/core/command/build.gradle.kts
@@ -25,8 +25,9 @@ plugins {
 dependencies {
     api(project(":core:model"))
     api(project(":platform:api"))
-    api(project(":shared"))
     api(project(":properties"))
+
+    implementation(project(":shared"))
 
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.kotlin.test.junit)

--- a/core/runtime/build.gradle.kts
+++ b/core/runtime/build.gradle.kts
@@ -24,14 +24,16 @@ plugins {
 
 dependencies {
     api(project(":core:command"))
-    api(project(":properties"))
     api(project(":core:model"))
-    api(project(":infrastructure:http"))
     api(project(":platform:api"))
-    api(project(":shared"))
 
+    implementation(project(":properties"))
+    implementation(project(":shared"))
     implementation(libs.slf4j.api)
-    implementation(libs.spring.boot.starter.jdbc)
+
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.kotlin.test.junit)
+    testRuntimeOnly(libs.junit.platform.launcher)
 
     compileOnly(libs.lombok)
     annotationProcessor(libs.lombok)

--- a/core/runtime/src/main/java/top/chiloven/lukosbot2/core/IUrlMediaLoader.java
+++ b/core/runtime/src/main/java/top/chiloven/lukosbot2/core/IUrlMediaLoader.java
@@ -15,27 +15,15 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-plugins {
-    `java-library`
-    alias(libs.plugins.kotlin.jvm)
-    alias(libs.plugins.kotlin.spring)
-    alias(libs.plugins.kotlin.lombok)
-}
+package top.chiloven.lukosbot2.core;
 
-dependencies {
-    implementation(project(":infrastructure:http"))
+import top.chiloven.lukosbot2.core.model.message.media.LoadedPlatformMedia;
+import top.chiloven.lukosbot2.core.model.message.media.UrlRef;
 
-    implementation(project(":shared"))
-    implementation(project(":core:model"))
-    implementation(project(":properties"))
-    implementation(project(":infrastructure:spring"))
+import java.io.IOException;
 
-    api(libs.jsoup)
-    api(libs.selenium.java)
+public interface IUrlMediaLoader {
 
-    implementation(libs.flexmark.html2md.converter)
-    implementation(libs.webdrivermanager)
+    LoadedPlatformMedia load(UrlRef ref) throws IOException;
 
-    compileOnly(libs.lombok)
-    annotationProcessor(libs.lombok)
 }

--- a/core/runtime/src/main/java/top/chiloven/lukosbot2/core/MediaRefLoader.java
+++ b/core/runtime/src/main/java/top/chiloven/lukosbot2/core/MediaRefLoader.java
@@ -20,7 +20,6 @@ package top.chiloven.lukosbot2.core;
 import org.springframework.stereotype.Component;
 import top.chiloven.lukosbot2.core.model.message.media.*;
 import top.chiloven.lukosbot2.platform.PlatformFileLoader;
-import top.chiloven.lukosbot2.util.HttpBytes;
 
 import java.io.IOException;
 import java.util.List;
@@ -29,23 +28,27 @@ import java.util.List;
 public class MediaRefLoader {
 
     private final List<PlatformFileLoader> platformFileLoaders;
+    private final IUrlMediaLoader urlMediaLoader;
 
-    public MediaRefLoader(List<PlatformFileLoader> platformFileLoaders) {
+    public MediaRefLoader(
+            List<PlatformFileLoader> platformFileLoaders,
+            IUrlMediaLoader urlMediaLoader
+    ) {
         this.platformFileLoaders = platformFileLoaders;
+        this.urlMediaLoader = urlMediaLoader;
     }
 
     public LoadedPlatformMedia load(MediaRef ref) throws IOException {
-        if (ref instanceof BytesRef(String name, byte[] bytes, String mime)) {
-            return new LoadedPlatformMedia(bytes, name, mime);
-        }
-        if (ref instanceof UrlRef(String url)) {
-            var remote = HttpBytes.getResponse(url).getBody();
-            return new LoadedPlatformMedia(remote.getBytes(), remote.getFileName(), remote.getMime());
-        }
-        if (ref instanceof PlatformFileRef platformFileRef) {
-            return loadPlatform(platformFileRef);
-        }
-        throw new IOException("不支持的媒体类型，无法读取。");
+        return switch (ref) {
+            case BytesRef(String name, byte[] bytes, String mime) -> new LoadedPlatformMedia(
+                    bytes,
+                    name,
+                    mime
+            );
+            case UrlRef(String url) -> urlMediaLoader.load(new UrlRef(url));
+            case PlatformFileRef platformFileRef -> loadPlatform(platformFileRef);
+            case null -> throw new IOException("不支持的媒体类型，无法读取。");
+        };
     }
 
     private LoadedPlatformMedia loadPlatform(PlatformFileRef ref) throws IOException {

--- a/core/runtime/src/main/java/top/chiloven/lukosbot2/core/MediaRefLoader.java
+++ b/core/runtime/src/main/java/top/chiloven/lukosbot2/core/MediaRefLoader.java
@@ -45,7 +45,7 @@ public class MediaRefLoader {
                     name,
                     mime
             );
-            case UrlRef(String url) -> urlMediaLoader.load(new UrlRef(url));
+            case UrlRef urlRef -> urlMediaLoader.load(urlRef);
             case PlatformFileRef platformFileRef -> loadPlatform(platformFileRef);
             case null -> throw new IOException("不支持的媒体类型，无法读取。");
         };

--- a/core/runtime/src/test/java/top/chiloven/lukosbot2/core/MediaRefLoaderTest.kt
+++ b/core/runtime/src/test/java/top/chiloven/lukosbot2/core/MediaRefLoaderTest.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2026 Chiloven945
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package top.chiloven.lukosbot2.core
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import top.chiloven.lukosbot2.core.model.message.media.BytesRef
+import top.chiloven.lukosbot2.core.model.message.media.LoadedPlatformMedia
+import top.chiloven.lukosbot2.core.model.message.media.PlatformFileRef
+import top.chiloven.lukosbot2.core.model.message.media.UrlRef
+import top.chiloven.lukosbot2.platform.PlatformFileLoader
+import java.io.IOException
+
+class MediaRefLoaderTest {
+
+    private class StubUrlMediaLoader(
+        private val result: LoadedPlatformMedia
+    ) : IUrlMediaLoader {
+
+        var loadedUrl: String? = null
+            private set
+
+        override fun load(ref: UrlRef): LoadedPlatformMedia {
+            loadedUrl = ref.url()
+            return result
+        }
+
+    }
+
+    private class StubPlatformFileLoader(
+        private val supportedPlatform: String,
+        private val result: LoadedPlatformMedia
+    ) : PlatformFileLoader {
+
+        override fun supports(platform: String): Boolean =
+            platform.equals(supportedPlatform, ignoreCase = true)
+
+        override fun load(ref: PlatformFileRef): LoadedPlatformMedia = result
+
+    }
+
+    @Test
+    fun `url ref delegates to url media loader`() {
+        val remote = LoadedPlatformMedia(
+            byteArrayOf(1, 2, 3),
+            "a.png",
+            "image/png"
+        )
+        val stub = StubUrlMediaLoader(remote)
+        val loader = MediaRefLoader(listOf(), stub)
+
+        val loaded = loader.load(UrlRef("https://example.com/a.png"))
+
+        assertSame(remote, loaded)
+        assertEquals("https://example.com/a.png", stub.loadedUrl)
+    }
+
+    @Test
+    fun `bytes ref returns bytes directly`() {
+        val loader = MediaRefLoader(
+            listOf(),
+            StubUrlMediaLoader(
+                LoadedPlatformMedia(
+                    byteArrayOf(0),
+                    null,
+                    null
+                )
+            )
+        )
+
+        val loaded = loader.load(
+            BytesRef(
+                "b.png",
+                byteArrayOf(1, 2, 3),
+                "image/png"
+            )
+        )
+
+        assertEquals("b.png", loaded.name())
+        assertEquals("image/png", loaded.mime())
+        assertArrayEquals(byteArrayOf(1, 2, 3), loaded.bytes())
+    }
+
+    @Test
+    fun `platform file ref delegates to matching platform file loader`() {
+        val expected = LoadedPlatformMedia(
+            byteArrayOf(9, 9),
+            "c.png",
+            "image/png"
+        )
+        val loader = MediaRefLoader(
+            listOf(
+                StubPlatformFileLoader(
+                    "discord",
+                    expected
+                )
+            ),
+            StubUrlMediaLoader(
+                LoadedPlatformMedia(
+                    byteArrayOf(0),
+                    null,
+                    null
+                )
+            )
+        )
+
+        val loaded = loader.load(PlatformFileRef("discord", "file-1"))
+
+        assertSame(expected, loaded)
+    }
+
+    @Test
+    fun `platform file ref without matching loader throws`() {
+        val loader = MediaRefLoader(
+            listOf(
+                StubPlatformFileLoader(
+                    "discord",
+                    LoadedPlatformMedia(
+                        byteArrayOf(0),
+                        null,
+                        null
+                    )
+                )
+            ),
+            StubUrlMediaLoader(
+                LoadedPlatformMedia(
+                    byteArrayOf(0),
+                    null,
+                    null
+                )
+            )
+        )
+
+        assertThrows(IOException::class.java) {
+            loader.load(PlatformFileRef("telegram", "file-1"))
+        }
+    }
+
+}

--- a/infrastructure/http/build.gradle.kts
+++ b/infrastructure/http/build.gradle.kts
@@ -23,12 +23,13 @@ plugins {
 }
 
 dependencies {
-    api(platform(libs.spring.boot.dependencies.bom))
-    api(project(":shared"))
-    api(project(":infrastructure:spring"))
+    implementation(platform(libs.spring.boot.dependencies.bom))
+    implementation(project(":shared"))
+    implementation(project(":infrastructure:spring"))
+    implementation(project(":core:runtime"))
     api(libs.jackson.core.databind)
     api(libs.okhttp)
-    api(libs.spring.boot.starter)
+    implementation(libs.spring.boot.starter)
 
     implementation(libs.kotlinx.coroutines.core)
 

--- a/infrastructure/http/src/main/java/top/chiloven/lukosbot2/http/HttpUrlMediaLoader.kt
+++ b/infrastructure/http/src/main/java/top/chiloven/lukosbot2/http/HttpUrlMediaLoader.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2026 Chiloven945
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package top.chiloven.lukosbot2.http
+
+import org.springframework.stereotype.Component
+import top.chiloven.lukosbot2.core.IUrlMediaLoader
+import top.chiloven.lukosbot2.core.model.message.media.LoadedPlatformMedia
+import top.chiloven.lukosbot2.core.model.message.media.UrlRef
+import top.chiloven.lukosbot2.util.HttpBytes
+import java.io.IOException
+
+@Component
+class HttpUrlMediaLoader : IUrlMediaLoader {
+
+    @Throws(IOException::class)
+    override fun load(ref: UrlRef): LoadedPlatformMedia {
+        val remote = HttpBytes.getResponse(ref.url()).body
+        return LoadedPlatformMedia(
+            remote.bytes, remote.fileName, remote.mime
+        )
+    }
+
+}

--- a/infrastructure/jdbc/build.gradle.kts
+++ b/infrastructure/jdbc/build.gradle.kts
@@ -17,25 +17,11 @@
  */
 plugins {
     `java-library`
-    alias(libs.plugins.kotlin.jvm)
-    alias(libs.plugins.kotlin.spring)
-    alias(libs.plugins.kotlin.lombok)
 }
 
 dependencies {
-    implementation(project(":infrastructure:http"))
-
-    implementation(project(":shared"))
-    implementation(project(":core:model"))
-    implementation(project(":properties"))
-    implementation(project(":infrastructure:spring"))
-
-    api(libs.jsoup)
-    api(libs.selenium.java)
-
-    implementation(libs.flexmark.html2md.converter)
-    implementation(libs.webdrivermanager)
-
-    compileOnly(libs.lombok)
-    annotationProcessor(libs.lombok)
+    implementation(project(":core:runtime"))
+    implementation(platform(libs.spring.boot.dependencies.bom))
+    implementation(libs.spring.boot.starter.jdbc)
+    implementation("org.springframework:spring-context")
 }

--- a/infrastructure/jdbc/src/main/java/top/chiloven/lukosbot2/core/state/store/JdbcStateStore.java
+++ b/infrastructure/jdbc/src/main/java/top/chiloven/lukosbot2/core/state/store/JdbcStateStore.java
@@ -48,8 +48,12 @@ public class JdbcStateStore implements IStateStore {
     }
 
     @Override
-    public Optional<String> getJson(Scope scope, String namespace, String key) {
-        String sql = """
+    public Optional<String> getJson(
+            Scope scope,
+            String namespace,
+            String key
+    ) {
+        var sql = """
                 SELECT v_json
                 FROM bot_state
                 WHERE scope_type=:st
@@ -64,13 +68,19 @@ public class JdbcStateStore implements IStateStore {
                 "ns", namespace,
                 "k", key
         );
-        var list = jdbc.query(sql, params, (rs, _) -> rs.getString(1));
-        return list.isEmpty() ? Optional.empty() : Optional.ofNullable(list.getFirst());
+        var list = jdbc.query(
+                sql,
+                params,
+                (rs, _) -> rs.getString(1)
+        );
+        return list.isEmpty()
+                ? Optional.empty()
+                : Optional.ofNullable(list.getFirst());
     }
 
     @Override
     public Map<String, String> getNamespaceJson(Scope scope, String namespace) {
-        String sql = """
+        var sql = """
                 SELECT k, v_json
                 FROM bot_state
                 WHERE scope_type=:st
@@ -84,68 +94,101 @@ public class JdbcStateStore implements IStateStore {
                 "sid", scope.id(),
                 "ns", namespace
         );
-        return jdbc.query(sql, params, rs -> {
-            Map<String, String> out = new LinkedHashMap<>();
-            while (rs.next()) {
-                out.put(rs.getString("k"), rs.getString("v_json"));
-            }
-            return out;
-        });
+        return jdbc.query(
+                sql,
+                params,
+                rs -> {
+                    Map<String, String> out = new LinkedHashMap<>();
+                    while (rs.next()) {
+                        out.put(
+                                rs.getString("k"),
+                                rs.getString("v_json")
+                        );
+                    }
+                    return out;
+                }
+        );
     }
 
     @Override
-    public void upsertJson(Scope scope, String namespace, String key, String json, Instant expiresAtOrNull) {
+    public void upsertJson(
+            Scope scope,
+            String namespace,
+            String key,
+            String json,
+            Instant expiresAtOrNull
+    ) {
         Map<String, Object> p = new HashMap<>();
         p.put("st", scope.type().name());
         p.put("sid", scope.id());
         p.put("ns", namespace);
         p.put("k", key);
         p.put("v", json);
-        p.put("exp", expiresAtOrNull == null ? null : Timestamp.from(expiresAtOrNull));
+        p.put(
+                "exp",
+                expiresAtOrNull == null
+                        ? null
+                        : Timestamp.from(expiresAtOrNull)
+        );
 
-        int updated = jdbc.update("""
-                UPDATE bot_state
-                   SET v_json=:v,
-                       expires_at=:exp,
-                       updated_at=CURRENT_TIMESTAMP,
-                       version=version+1
-                 WHERE scope_type=:st
-                   AND scope_id=:sid
-                   AND namespace=:ns
-                   AND k=:k
-                """, p);
+        int updated = jdbc.update(
+                """
+                        UPDATE bot_state
+                           SET v_json=:v,
+                               expires_at=:exp,
+                               updated_at=CURRENT_TIMESTAMP,
+                               version=version+1
+                         WHERE scope_type=:st
+                           AND scope_id=:sid
+                           AND namespace=:ns
+                           AND k=:k
+                        """,
+                p
+        );
 
-        if (updated != 0) return;
+        if (updated != 0) {
+            return;
+        }
 
         try {
-            jdbc.update("""
-                    INSERT INTO bot_state(
-                        scope_type, scope_id, namespace, k,
-                        v_json, expires_at, created_at, updated_at, version
-                    ) VALUES (
-                        :st, :sid, :ns, :k,
-                        :v, :exp, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0
-                    )
-                    """, p);
+            jdbc.update(
+                    """
+                            INSERT INTO bot_state(
+                                scope_type, scope_id, namespace, k,
+                                v_json, expires_at, created_at, updated_at, version
+                            ) VALUES (
+                                :st, :sid, :ns, :k,
+                                :v, :exp, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0
+                            )
+                            """,
+                    p
+            );
         } catch (DuplicateKeyException e) {
             // concurrent insert: retry update
-            jdbc.update("""
-                    UPDATE bot_state
-                       SET v_json=:v,
-                           expires_at=:exp,
-                           updated_at=CURRENT_TIMESTAMP,
-                           version=version+1
-                     WHERE scope_type=:st
-                       AND scope_id=:sid
-                       AND namespace=:ns
-                       AND k=:k
-                    """, p);
+            jdbc.update(
+                    """
+                            UPDATE bot_state
+                               SET v_json=:v,
+                                   expires_at=:exp,
+                                   updated_at=CURRENT_TIMESTAMP,
+                                   version=version+1
+                             WHERE scope_type=:st
+                               AND scope_id=:sid
+                               AND namespace=:ns
+                               AND k=:k
+                            """,
+                    p
+            );
         }
     }
 
     @Override
-    public void delete(Scope scope, String namespace, String key) {
-        String sql = """
+    public void delete(
+            Scope scope,
+            String namespace,
+            String key
+    ) {
+        var sql = """
                 DELETE FROM bot_state
                 WHERE scope_type=:st
                   AND scope_id=:sid
@@ -162,8 +205,11 @@ public class JdbcStateStore implements IStateStore {
     }
 
     @Override
-    public Map<String, Map<String, String>> scanByScopeTypeAndNamespace(ScopeType type, String namespace) {
-        String sql = """
+    public Map<String, Map<String, String>> scanByScopeTypeAndNamespace(
+            ScopeType type,
+            String namespace
+    ) {
+        var sql = """
                 SELECT scope_id, k, v_json
                 FROM bot_state
                 WHERE scope_type=:st
@@ -176,16 +222,20 @@ public class JdbcStateStore implements IStateStore {
                 "ns", namespace
         );
 
-        return jdbc.query(sql, params, rs -> {
-            Map<String, Map<String, String>> out = new LinkedHashMap<>();
-            while (rs.next()) {
-                String sid = rs.getString("scope_id");
-                String k = rs.getString("k");
-                String v = rs.getString("v_json");
-                out.computeIfAbsent(sid, _ -> new LinkedHashMap<>()).put(k, v);
-            }
-            return out;
-        });
+        return jdbc.query(
+                sql,
+                params,
+                rs -> {
+                    Map<String, Map<String, String>> out = new LinkedHashMap<>();
+                    while (rs.next()) {
+                        String sid = rs.getString("scope_id");
+                        String k = rs.getString("k");
+                        String v = rs.getString("v_json");
+                        out.computeIfAbsent(sid, _ -> new LinkedHashMap<>()).put(k, v);
+                    }
+                    return out;
+                }
+        );
     }
 
 }

--- a/properties/build.gradle.kts
+++ b/properties/build.gradle.kts
@@ -23,11 +23,11 @@ plugins {
 }
 
 dependencies {
-    api(project(":shared"))
-    api(project(":infrastructure:spring"))
+    implementation(project(":shared"))
+    implementation(project(":infrastructure:spring"))
 
-    api(platform(libs.spring.boot.dependencies.bom))
-    api(libs.spring.boot.starter)
+    implementation(platform(libs.spring.boot.dependencies.bom))
+    implementation(libs.spring.boot.starter)
 
     compileOnly(libs.lombok)
     annotationProcessor(platform(libs.spring.boot.dependencies.bom))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -48,6 +48,7 @@ include(":platform:discord")
 
 include(":infrastructure:spring")
 include(":infrastructure:http")
+include(":infrastructure:jdbc")
 include(":infrastructure:web-infra")
 
 include(":commands:basic")


### PR DESCRIPTION
- invert URL media loading via IUrlMediaLoader core port, replacing the
  core:runtime -> infrastructure:http dependency with an HttpUrlMediaLoader
  adapter in infrastructure:http
- move JdbcStateStore into the new :infrastructure:jdbc module and drop
  spring-boot-starter-jdbc from core:runtime
- downgrade api() to implementation() for dependencies not exposed in
  public API surfaces (core:runtime, core:command, infrastructure:http,
  infrastructure:web-infra, properties)
- wire :infrastructure:jdbc into :app and settings
- add MediaRefLoader regression tests

## Summary by Sourcery

Decouple core runtime from HTTP and JDBC infrastructure while preserving media loading and state persistence through dedicated adapters.

New Features:
- Add an HTTP-backed media URL loader adapter behind a core media-loading port.

Bug Fixes:
- Correct module dependency direction by removing infrastructure dependencies from core runtime.
- Restore JDBC state persistence through a dedicated infrastructure module without coupling core runtime to JDBC.

Enhancements:
- Limit Gradle dependencies to implementation scope where they are not part of public APIs.
- Register the JDBC infrastructure module with the application and build.

Build:
- Add and include the new :infrastructure:jdbc Gradle module.

Tests:
- Add regression coverage for URL, byte-based, and platform-file media reference loading.